### PR TITLE
ignore NSURLErrorCancelled

### DIFF
--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -936,9 +936,9 @@
 {
     // log fail message, stop spinner, update back/forward
     NSLog(@"webView:didFailLoadWithError - %ld: %@", (long)error.code, [error localizedDescription]);
-	
-	if (error.code == NSURLErrorCancelled)
-	    return;
+
+    if (error.code == NSURLErrorCancelled)
+        return;
 
     self.backButton.enabled = theWebView.canGoBack;
     self.forwardButton.enabled = theWebView.canGoForward;

--- a/src/ios/CDVInAppBrowser.m
+++ b/src/ios/CDVInAppBrowser.m
@@ -472,7 +472,7 @@
 
 - (void)webView:(UIWebView*)theWebView didFailLoadWithError:(NSError*)error
 {
-    if (self.callbackId != nil) {
+    if ( (self.callbackId != nil) || (error.code != NSURLErrorCancelled) ) {
         NSString* url = [self.inAppBrowserViewController.currentURL absoluteString];
         CDVPluginResult* pluginResult = [CDVPluginResult resultWithStatus:CDVCommandStatus_ERROR
                                                       messageAsDictionary:@{@"type":@"loaderror", @"url":url, @"code": [NSNumber numberWithInteger:error.code], @"message": error.localizedDescription}];
@@ -936,6 +936,9 @@
 {
     // log fail message, stop spinner, update back/forward
     NSLog(@"webView:didFailLoadWithError - %ld: %@", (long)error.code, [error localizedDescription]);
+	
+	if (error.code == NSURLErrorCancelled)
+	    return;
 
     self.backButton.enabled = theWebView.canGoBack;
     self.forwardButton.enabled = theWebView.canGoForward;


### PR DESCRIPTION
SMT-468 
### Platforms affected
iOS

### What does this PR do?
On iOS, an NSURLErrorCancelled error is generated when a load request is interrupted by another load request. This code change ignores the NSURLErrorCancelled if it happens.

### What testing has been done on this change?
Tested the Serraview app with SSO login
